### PR TITLE
Fixes BOTW & TOTK

### DIFF
--- a/src/nxemu-os/core/hle/service/aoc/addon_content_manager.cpp
+++ b/src/nxemu-os/core/hle/service/aoc/addon_content_manager.cpp
@@ -46,8 +46,7 @@ namespace FileSys {
 namespace Service::AOC {
 
 static bool CheckAOCTitleIDMatchesBase(u64 title_id, u64 base) {
-    UNIMPLEMENTED();
-    return false;
+    return FileSys::GetBaseTitleID(title_id) == base;
 }
 
 static std::vector<u64> AccumulateAOCTitleIDs(Core::System & system) {
@@ -164,7 +163,11 @@ Result IAddOnContentManager::ListAddOnContent(Out<u32> out_count,
 
 Result IAddOnContentManager::GetAddOnContentBaseId(Out<u64> out_title_id,
                                                    ClientProcessId process_id) {
-    UNIMPLEMENTED();
+    LOG_DEBUG(Service_AOC, "called, process_id={}", process_id.pid);
+
+    const u64 application_id = system.GetApplicationProcessProgramID();
+    *out_title_id = FileSys::GetBaseTitleID(application_id) | 0x1000;
+
     R_SUCCEED();
 }
 

--- a/src/nxemu-os/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.cpp
+++ b/src/nxemu-os/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.cpp
@@ -1,11 +1,38 @@
 // SPDX-FileCopyrightText: Copyright 2018 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "yuzu_common/hex_util.h"
+#include <algorithm>
 #include "core/hle/service/cmif_serialization.h"
 #include "core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.h"
 
 namespace Service::FileSystem {
 
+ISaveDataInfoReader::ISaveDataInfoReader(Core::System& system_)
+    : ServiceFramework{system_, "ISaveDataInfoReader"} {
+    static const FunctionInfo functions[] = {
+        {0, D<&ISaveDataInfoReader::ReadSaveDataInfo>, "ReadSaveDataInfo"},
+    };
+    RegisterHandlers(functions);
+}
+
+ISaveDataInfoReader::~ISaveDataInfoReader() = default;
+
+// Returns an empty iterator. nxemu does not currently enumerate save data;
+// callers receive out_count = 0, which is a legal end-of-iteration response.
+Result ISaveDataInfoReader::ReadSaveDataInfo(
+    Out<u64> out_count, OutArray<SaveDataInfo, BufferAttr_HipcMapAlias> out_entries) {
+    LOG_DEBUG(Service_FS, "called");
+
+    const u64 remaining = info.size() > next_entry_index ? info.size() - next_entry_index : 0;
+    const u64 to_copy = std::min<u64>(remaining, out_entries.size());
+
+    for (u64 i = 0; i < to_copy; ++i) {
+        out_entries[i] = info[next_entry_index + i];
+    }
+    next_entry_index += to_copy;
+    *out_count = to_copy;
+
+    R_SUCCEED();
+}
 
 } // namespace Service::FileSystem

--- a/src/nxemu-os/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.h
+++ b/src/nxemu-os/core/hle/service/filesystem/fsp/fs_i_save_data_info_reader.h
@@ -11,11 +11,9 @@
 
 namespace Service::FileSystem {
 
-class SaveDataController;
-
 class ISaveDataInfoReader final : public ServiceFramework<ISaveDataInfoReader> {
 public:
-    explicit ISaveDataInfoReader(Core::System& system_, std::shared_ptr<SaveDataController> save_data_controller_, SaveDataSpaceId space);
+    explicit ISaveDataInfoReader(Core::System& system_);
     ~ISaveDataInfoReader() override;
 
     struct SaveDataInfo {
@@ -37,9 +35,6 @@ public:
                             OutArray<SaveDataInfo, BufferAttr_HipcMapAlias> out_entries);
 
 private:
-    void FindAllSaves(SaveDataSpaceId space);
-
-    std::shared_ptr<SaveDataController> save_data_controller;
     std::vector<SaveDataInfo> info;
     u64 next_entry_index = 0;
 };

--- a/src/nxemu-os/core/hle/service/filesystem/fsp/fsp_srv.cpp
+++ b/src/nxemu-os/core/hle/service/filesystem/fsp/fsp_srv.cpp
@@ -248,10 +248,15 @@ Result FSP_SRV::OpenSaveDataFileSystem(OutInterface<IFileSystem> out_interface, 
     case SaveDataSpaceId::System:
         id = StorageId::NandSystem;
         break;
+    // Temporary/ProperSystem/SafeMode aren't backed by separate storage yet;
+    // pick the closest underlying StorageId so SizeGetter::FromStorageId returns sane values.
     case SaveDataSpaceId::Temporary:
+        id = StorageId::NandUser;
+        break;
     case SaveDataSpaceId::ProperSystem:
     case SaveDataSpaceId::SafeMode:
-        ASSERT(false);
+        id = StorageId::NandSystem;
+        break;
     }
 
     *out_interface = std::make_shared<IFileSystem>(system, std::move(dir), SizeGetter::FromStorageId(fsc, id));
@@ -272,15 +277,17 @@ Result FSP_SRV::OpenReadOnlySaveDataFileSystem(OutInterface<IFileSystem> out_int
 
 Result FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(OutInterface<ISaveDataInfoReader> out_interface, SaveDataSpaceId space)
 {
-    LOG_INFO(Service_FS, "called, space={}", space);
-    UNIMPLEMENTED();
+    LOG_WARNING(Service_FS, "(STUBBED) called, space={}", space);
+
+    *out_interface = std::make_shared<ISaveDataInfoReader>(system);
     R_SUCCEED();
 }
 
 Result FSP_SRV::OpenSaveDataInfoReaderOnlyCacheStorage(OutInterface<ISaveDataInfoReader> out_interface)
 {
     LOG_WARNING(Service_FS, "(STUBBED) called");
-    UNIMPLEMENTED();
+
+    *out_interface = std::make_shared<ISaveDataInfoReader>(system);
     R_SUCCEED();
 }
 

--- a/src/nxemu-os/core/hle/service/nfc/nfc_interface.cpp
+++ b/src/nxemu-os/core/hle/service/nfc/nfc_interface.cpp
@@ -80,7 +80,13 @@ void NfcInterface::GetNpadId(HLERequestContext& ctx) {
 }
 
 void NfcInterface::AttachAvailabilityChangeEvent(HLERequestContext& ctx) {
-    UNIMPLEMENTED();
+    LOG_INFO(Service_NFC, "called");
+
+    auto manager = GetManager();
+
+    IPC::ResponseBuilder rb{ctx, 2, 1};
+    rb.Push(ResultSuccess);
+    rb.PushCopyObjects(manager->AttachAvailabilityChangeEvent());
 }
 
 void NfcInterface::StartDetection(HLERequestContext& ctx) {

--- a/src/nxemu-video/video_manager.cpp
+++ b/src/nxemu-video/video_manager.cpp
@@ -308,13 +308,9 @@ void VideoManager::PushCommandBuffer(int32_t bindId, const uint32_t * commandLis
 void VideoManager::ApplyOpOnDeviceMemoryPointer(const uint8_t * pointer, uint32_t * scratchBuffer, size_t scratchBufferSize, DeviceMemoryOperation operation, void * userData)
 {
     Common::ScratchBuffer<u32> tempBuffer;
-    tempBuffer.resize(scratchBufferSize);
-    std::memcpy(tempBuffer.data(), scratchBuffer, scratchBufferSize * sizeof(uint32_t));
-
     impl->m_host1x->MemoryManager().ApplyOpOnPointer(pointer, tempBuffer, [operation, userData](DAddr address) {
         operation(address, userData);
     });
-    std::memcpy(scratchBuffer, tempBuffer.data(), tempBuffer.size() * sizeof(uint32_t));
 }
 
 RasterizerDownloadArea VideoManager::OnCPURead(uint64_t addr, uint64_t size)


### PR DESCRIPTION
## Summary

- Fixes Breath of the Wild launch
- Fixes Tears of the Kingdom launch

## Commits

- `implement aoc:u GetAddOnContentBaseId` — BOTW DLC base id resolution
- `fsp_srv: stub ISaveDataInfoReader, map save spaces` — TOTK cache-storage probe
- `nfc: implement AttachAvailabilityChangeEvent` — TOTK Amiibo init
- `video_manager: stop overflowing the scratch buffer` — TOTK GPU readback

## Test plan
- [x] BOTW boots to gameplay
- [x] TOTK boots to gameplay (previously crashed at ~14 s on NFC, then ~30 s on the video memcpy)