### PR TITLE
Fix up x64 detection

### DIFF
--- a/src/nxemu-cpu/cpu_manager.cpp
+++ b/src/nxemu-cpu/cpu_manager.cpp
@@ -5,7 +5,7 @@
 #include "arm_dynarmic_64.h"
 #include "arm_dynarmic_32.h"
 #include "patch/patch_collection.h"
-#if defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_arm64)
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_arm64)
 #include "exclusive_monitor_interface.h"
 #endif
 
@@ -28,7 +28,7 @@ bool CpuInterface::Initialize(void)
 
 IExclusiveMonitor * CpuInterface::CreateExclusiveMonitor(IMemory & memory)
 {
-#if defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_arm64)
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_arm64)
     return new ExclusiveMonitor(memory, m_monitor);
 #else
     // TODO(merry): Passthrough exclusive monitor

--- a/src/nxemu-cpu/dynarmic_cp15.cpp
+++ b/src/nxemu-cpu/dynarmic_cp15.cpp
@@ -56,10 +56,10 @@ CallbackOrAccessOneWord DynarmicCP15::CompileSendOneWord(bool two, unsigned opc1
             // CP15_DATA_SYNC_BARRIER
             return Callback{
                 [](void *, std::uint32_t, std::uint32_t) -> std::uint64_t {
-#if defined(_MSC_VER) && defined(ARCHITECTURE_x86_64)
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(ARCHITECTURE_x86_64))
                     _mm_mfence();
                     _mm_lfence();
-#elif defined(ARCHITECTURE_x86_64)
+#elif defined(_M_X64) || defined(ARCHITECTURE_x86_64)
                     asm volatile("mfence\n\tlfence\n\t" : : : "memory");
 #elif defined(ARCHITECTURE_arm64)
                     asm volatile("dsb sy\n\t" : : : "memory");
@@ -74,9 +74,9 @@ CallbackOrAccessOneWord DynarmicCP15::CompileSendOneWord(bool two, unsigned opc1
             // CP15_DATA_MEMORY_BARRIER
             return Callback{
                 [](void *, std::uint32_t, std::uint32_t) -> std::uint64_t {
-#if defined(_MSC_VER) && defined(ARCHITECTURE_x86_64)
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(ARCHITECTURE_x86_64))
                     _mm_mfence();
-#elif defined(ARCHITECTURE_x86_64)
+#elif defined(_M_X64) || defined(ARCHITECTURE_x86_64)
                     asm volatile("mfence\n\t" : : : "memory");
 #elif defined(ARCHITECTURE_arm64)
                     asm volatile("dmb sy\n\t" : : : "memory");

--- a/src/nxemu-cpu/nxemu-cpu.vcxproj
+++ b/src/nxemu-cpu/nxemu-cpu.vcxproj
@@ -31,7 +31,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)src\3rd_party\SoftFloat-3e\source\include;$(SolutionDir)external\boost;$(SolutionDir)external\mcl\include;$(SolutionDir)external\fmt\include;$(SolutionDir)external\robin-map\include;$(SolutionDir)external\xbyak;$(SolutionDir)external\zydis\include;$(SolutionDir)external\oaknut\include;$(SolutionDir)external\zycore\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <UseStandardPreprocessor>true</UseStandardPreprocessor>
-      <PreprocessorDefinitions>NOMINMAX;DYNARMIC_ENABLE_CPU_FEATURE_DETECTION=1;MCL_IGNORE_ASSERTS=1;FMT_STATIC_LINK;FMT_USE_WINDOWS_H=0;FMT_USE_USER_DEFINED_LITERALS=1;ARCHITECTURE_x86_64=1;BOOST_ASIO_DISABLE_CONCEPTS;_HAS_DEPRECATED_RESULT_OF;_WIN32_WINNT=0x0A00;WINVER=0x0A00;BOOST_ALL_NO_LIB;ZYDIS_STATIC_BUILD;ZYCORE_STATIC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;DYNARMIC_ENABLE_CPU_FEATURE_DETECTION=1;MCL_IGNORE_ASSERTS=1;FMT_STATIC_LINK;FMT_USE_WINDOWS_H=0;FMT_USE_USER_DEFINED_LITERALS=1;BOOST_ASIO_DISABLE_CONCEPTS;_HAS_DEPRECATED_RESULT_OF;_WIN32_WINNT=0x0A00;WINVER=0x0A00;BOOST_ALL_NO_LIB;ZYDIS_STATIC_BUILD;ZYCORE_STATIC_BUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions> /bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <PreBuildEvent>

--- a/src/nxemu-os/core/core_timing.cpp
+++ b/src/nxemu-os/core/core_timing.cpp
@@ -10,7 +10,7 @@
 #include "yuzu_common/windows/timer_resolution.h"
 #endif
 
-#ifdef ARCHITECTURE_x86_64
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
 #include "yuzu_common/x64/cpu_wait.h"
 #endif
 
@@ -272,7 +272,7 @@ void CoreTiming::ThreadLoop() {
                         if (wait_time >= timer_resolution_ns) {
                             Common::Windows::SleepForOneTick();
                         } else {
-#ifdef ARCHITECTURE_x86_64
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
                             Common::X64::MicroSleep();
 #else
                             std::this_thread::yield();

--- a/src/yuzu_common/common_funcs.h
+++ b/src/yuzu_common/common_funcs.h
@@ -6,7 +6,7 @@
 #include <array>
 #include <iterator>
 
-#if !defined(ARCHITECTURE_x86_64)
+#if !(defined(_M_X64) || defined(ARCHITECTURE_x86_64))
 #include <cstdlib> // for exit
 #endif
 #include "yuzu_common/common_types.h"
@@ -31,7 +31,7 @@
 
 #ifndef _MSC_VER
 
-#if defined(ARCHITECTURE_x86_64)
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
 #define Crash() __asm__ __volatile__("int $3")
 #elif defined(ARCHITECTURE_arm64)
 #define Crash() __asm__ __volatile__("brk #0")

--- a/src/yuzu_common/uint128.h
+++ b/src/yuzu_common/uint128.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright 2019 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <utility>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#pragma intrinsic(__umulh)
+#pragma intrinsic(_umul128)
+#pragma intrinsic(_udiv128)
+#else
+#include <cstring>
+#endif
+
+#include "yuzu_common/common_types.h"
+
+namespace Common {
+
+// This function multiplies 2 u64 values and divides it by a u64 value.
+[[nodiscard]] static inline u64 MultiplyAndDivide64(u64 a, u64 b, u64 d) {
+#ifdef _MSC_VER
+    u128 r{};
+    r[0] = _umul128(a, b, &r[1]);
+    u64 remainder;
+#if _MSC_VER < 1923
+    return udiv128(r[1], r[0], d, &remainder);
+#else
+    return _udiv128(r[1], r[0], d, &remainder);
+#endif
+#else
+    const u64 diva = a / d;
+    const u64 moda = a % d;
+    const u64 divb = b / d;
+    const u64 modb = b % d;
+    return diva * b + moda * divb + moda * modb / d;
+#endif
+}
+
+// This function multiplies 2 u64 values and produces a u128 value;
+[[nodiscard]] static inline u128 Multiply64Into128(u64 a, u64 b) {
+    u128 result;
+#ifdef _MSC_VER
+    result[0] = _umul128(a, b, &result[1]);
+#else
+    unsigned __int128 tmp = a;
+    tmp *= b;
+    std::memcpy(&result, &tmp, sizeof(u128));
+#endif
+    return result;
+}
+
+[[nodiscard]] static inline u64 GetFixedPoint64Factor(u64 numerator, u64 divisor) {
+#ifdef __SIZEOF_INT128__
+    const auto base = static_cast<unsigned __int128>(numerator) << 64ULL;
+    return static_cast<u64>(base / divisor);
+#elif defined(_M_X64) || defined(_M_ARM64)
+    std::array<u64, 2> r = {0, numerator};
+    u64 remainder;
+#if _MSC_VER < 1923
+    return udiv128(r[1], r[0], divisor, &remainder);
+#else
+    return _udiv128(r[1], r[0], divisor, &remainder);
+#endif
+#else
+    // This one is bit more inaccurate.
+    return MultiplyAndDivide64(std::numeric_limits<u64>::max(), numerator, divisor);
+#endif
+}
+
+[[nodiscard]] static inline u64 MultiplyHigh(u64 a, u64 b) {
+#ifdef __SIZEOF_INT128__
+    return (static_cast<unsigned __int128>(a) * static_cast<unsigned __int128>(b)) >> 64;
+#elif defined(_M_X64) || defined(_M_ARM64)
+    return __umulh(a, b); // MSVC
+#else
+    // Generic fallback
+    const u64 a_lo = u32(a);
+    const u64 a_hi = a >> 32;
+    const u64 b_lo = u32(b);
+    const u64 b_hi = b >> 32;
+
+    const u64 a_x_b_hi = a_hi * b_hi;
+    const u64 a_x_b_mid = a_hi * b_lo;
+    const u64 b_x_a_mid = b_hi * a_lo;
+    const u64 a_x_b_lo = a_lo * b_lo;
+
+    const u64 carry_bit = (static_cast<u64>(static_cast<u32>(a_x_b_mid)) +
+                           static_cast<u64>(static_cast<u32>(b_x_a_mid)) + (a_x_b_lo >> 32)) >>
+                          32;
+
+    const u64 multhi = a_x_b_hi + (a_x_b_mid >> 32) + (b_x_a_mid >> 32) + carry_bit;
+
+    return multhi;
+#endif
+}
+
+// This function divides a u128 by a u32 value and produces two u64 values:
+// the result of division and the remainder
+[[nodiscard]] static inline std::pair<u64, u64> Divide128On32(u128 dividend, u32 divisor) {
+    u64 remainder = dividend[0] % divisor;
+    u64 accum = dividend[0] / divisor;
+    if (dividend[1] == 0)
+        return {accum, remainder};
+    // We ignore dividend[1] / divisor as that overflows
+    const u64 first_segment = (dividend[1] % divisor) << 32;
+    accum += (first_segment / divisor) << 32;
+    const u64 second_segment = (first_segment % divisor) << 32;
+    accum += (second_segment / divisor);
+    remainder += second_segment % divisor;
+    if (remainder >= divisor) {
+        accum++;
+        remainder -= divisor;
+    }
+    return {accum, remainder};
+}
+
+} // namespace Common

--- a/src/yuzu_common/wall_clock.cpp
+++ b/src/yuzu_common/wall_clock.cpp
@@ -4,7 +4,7 @@
 #include "yuzu_common/steady_clock.h"
 #include "yuzu_common/wall_clock.h"
 
-#ifdef ARCHITECTURE_x86_64
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
 #include "yuzu_common/x64/cpu_detect.h"
 #include "yuzu_common/x64/native_clock.h"
 #include "yuzu_common/x64/rdtsc.h"
@@ -55,7 +55,7 @@ public:
 };
 
 std::unique_ptr<WallClock> CreateOptimalClock() {
-#if defined(ARCHITECTURE_x86_64)
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
     const auto& caps = GetCPUCaps();
 
     if (caps.invariant_tsc && caps.tsc_frequency >= std::nano::den) {

--- a/src/yuzu_common/x64/cpu_detect.cpp
+++ b/src/yuzu_common/x64/cpu_detect.cpp
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-FileCopyrightText: Copyright 2013 Dolphin Emulator Project / 2015 Citra Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <array>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <string_view>
+#include <thread>
+#include <vector>
+#include "yuzu_common/bit_util.h"
+#include "yuzu_common/common_types.h"
+#include "yuzu_common/logging/log.h"
+#include "yuzu_common/x64/cpu_detect.h"
+#include "yuzu_common/x64/rdtsc.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#ifdef _MSC_VER
+#include <intrin.h>
+
+static inline u64 xgetbv(u32 index) {
+    return _xgetbv(index);
+}
+#else
+
+#if defined(__DragonFly__) || defined(__FreeBSD__)
+// clang-format off
+#include <sys/types.h>
+#include <machine/cpufunc.h>
+// clang-format on
+#endif
+
+static inline void __cpuidex(int info[4], u32 function_id, u32 subfunction_id) {
+#if defined(__DragonFly__) || defined(__FreeBSD__)
+    // Despite the name, this is just do_cpuid() with ECX as second input.
+    cpuid_count((u_int)function_id, (u_int)subfunction_id, (u_int*)info);
+#else
+    info[0] = function_id;    // eax
+    info[2] = subfunction_id; // ecx
+    __asm__("cpuid"
+            : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3])
+            : "a"(function_id), "c"(subfunction_id));
+#endif
+}
+
+static inline void __cpuid(int info[4], u32 function_id) {
+    return __cpuidex(info, function_id, 0);
+}
+
+#define _XCR_XFEATURE_ENABLED_MASK 0
+static inline u64 xgetbv(u32 index) {
+    u32 eax, edx;
+    __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
+    return ((u64)edx << 32) | eax;
+}
+#endif // _MSC_VER
+
+namespace Common {
+
+CPUCaps::Manufacturer CPUCaps::ParseManufacturer(std::string_view brand_string) {
+    if (brand_string == "GenuineIntel") {
+        return Manufacturer::Intel;
+    } else if (brand_string == "AuthenticAMD") {
+        return Manufacturer::AMD;
+    } else if (brand_string == "HygonGenuine") {
+        return Manufacturer::Hygon;
+    }
+    return Manufacturer::Unknown;
+}
+
+// Detects the various CPU features
+static CPUCaps Detect() {
+    CPUCaps caps = {};
+
+    // Assumes the CPU supports the CPUID instruction. Those that don't would likely not support
+    // yuzu at all anyway
+
+    int cpu_id[4];
+
+    // Detect CPU's CPUID capabilities and grab manufacturer string
+    __cpuid(cpu_id, 0x00000000);
+    const u32 max_std_fn = cpu_id[0]; // EAX
+
+    std::memset(caps.brand_string, 0, std::size(caps.brand_string));
+    std::memcpy(&caps.brand_string[0], &cpu_id[1], sizeof(u32));
+    std::memcpy(&caps.brand_string[4], &cpu_id[3], sizeof(u32));
+    std::memcpy(&caps.brand_string[8], &cpu_id[2], sizeof(u32));
+
+    caps.manufacturer = CPUCaps::ParseManufacturer(caps.brand_string);
+
+    // Set reasonable default cpu string even if brand string not available
+    std::strncpy(caps.cpu_string, caps.brand_string, std::size(caps.brand_string));
+
+    __cpuid(cpu_id, 0x80000000);
+
+    const u32 max_ex_fn = cpu_id[0];
+
+    // Detect family and other miscellaneous features
+    if (max_std_fn >= 1) {
+        __cpuid(cpu_id, 0x00000001);
+        caps.sse = Common::Bit<25>(cpu_id[3]);
+        caps.sse2 = Common::Bit<26>(cpu_id[3]);
+        caps.sse3 = Common::Bit<0>(cpu_id[2]);
+        caps.pclmulqdq = Common::Bit<1>(cpu_id[2]);
+        caps.ssse3 = Common::Bit<9>(cpu_id[2]);
+        caps.sse4_1 = Common::Bit<19>(cpu_id[2]);
+        caps.sse4_2 = Common::Bit<20>(cpu_id[2]);
+        caps.movbe = Common::Bit<22>(cpu_id[2]);
+        caps.popcnt = Common::Bit<23>(cpu_id[2]);
+        caps.aes = Common::Bit<25>(cpu_id[2]);
+        caps.f16c = Common::Bit<29>(cpu_id[2]);
+
+        // AVX support requires 3 separate checks:
+        //  - Is the AVX bit set in CPUID?
+        //  - Is the XSAVE bit set in CPUID?
+        //  - XGETBV result has the XCR bit set.
+        if (Common::Bit<28>(cpu_id[2]) && Common::Bit<27>(cpu_id[2])) {
+            if ((xgetbv(_XCR_XFEATURE_ENABLED_MASK) & 0x6) == 0x6) {
+                caps.avx = true;
+                if (Common::Bit<12>(cpu_id[2]))
+                    caps.fma = true;
+            }
+        }
+
+        if (max_std_fn >= 7) {
+            __cpuidex(cpu_id, 0x00000007, 0x00000000);
+            // Can't enable AVX{2,512} unless the XSAVE/XGETBV checks above passed
+            if (caps.avx) {
+                caps.avx2 = Common::Bit<5>(cpu_id[1]);
+                caps.avx512f = Common::Bit<16>(cpu_id[1]);
+                caps.avx512dq = Common::Bit<17>(cpu_id[1]);
+                caps.avx512cd = Common::Bit<28>(cpu_id[1]);
+                caps.avx512bw = Common::Bit<30>(cpu_id[1]);
+                caps.avx512vl = Common::Bit<31>(cpu_id[1]);
+                caps.avx512vbmi = Common::Bit<1>(cpu_id[2]);
+                caps.avx512bitalg = Common::Bit<12>(cpu_id[2]);
+            }
+
+            caps.bmi1 = Common::Bit<3>(cpu_id[1]);
+            caps.bmi2 = Common::Bit<8>(cpu_id[1]);
+            caps.sha = Common::Bit<29>(cpu_id[1]);
+
+            caps.waitpkg = Common::Bit<5>(cpu_id[2]);
+            caps.gfni = Common::Bit<8>(cpu_id[2]);
+
+            __cpuidex(cpu_id, 0x00000007, 0x00000001);
+            caps.avx_vnni = caps.avx && Common::Bit<4>(cpu_id[0]);
+        }
+    }
+
+    if (max_ex_fn >= 0x80000004) {
+        // Extract CPU model string
+        __cpuid(cpu_id, 0x80000002);
+        std::memcpy(caps.cpu_string, cpu_id, sizeof(cpu_id));
+        __cpuid(cpu_id, 0x80000003);
+        std::memcpy(caps.cpu_string + 16, cpu_id, sizeof(cpu_id));
+        __cpuid(cpu_id, 0x80000004);
+        std::memcpy(caps.cpu_string + 32, cpu_id, sizeof(cpu_id));
+    }
+
+    if (max_ex_fn >= 0x80000001) {
+        // Check for more features
+        __cpuid(cpu_id, 0x80000001);
+        caps.lzcnt = Common::Bit<5>(cpu_id[2]);
+        caps.fma4 = Common::Bit<16>(cpu_id[2]);
+        caps.monitorx = Common::Bit<29>(cpu_id[2]);
+    }
+
+    if (max_ex_fn >= 0x80000007) {
+        __cpuid(cpu_id, 0x80000007);
+        caps.invariant_tsc = Common::Bit<8>(cpu_id[3]);
+    }
+
+    if (max_std_fn >= 0x15) {
+        __cpuid(cpu_id, 0x15);
+        caps.tsc_crystal_ratio_denominator = cpu_id[0];
+        caps.tsc_crystal_ratio_numerator = cpu_id[1];
+        caps.crystal_frequency = cpu_id[2];
+        // Some CPU models might not return a crystal frequency.
+        // The CPU model can be detected to use the values from turbostat
+        // https://github.com/torvalds/linux/blob/master/tools/power/x86/turbostat/turbostat.c#L5569
+        // but it's easier to just estimate the TSC tick rate for these cases.
+        if (caps.tsc_crystal_ratio_denominator) {
+            caps.tsc_frequency = static_cast<u64>(caps.crystal_frequency) *
+                                 caps.tsc_crystal_ratio_numerator /
+                                 caps.tsc_crystal_ratio_denominator;
+        } else {
+            caps.tsc_frequency = X64::EstimateRDTSCFrequency();
+        }
+    }
+
+    if (max_std_fn >= 0x16) {
+        __cpuid(cpu_id, 0x16);
+        caps.base_frequency = cpu_id[0];
+        caps.max_frequency = cpu_id[1];
+        caps.bus_frequency = cpu_id[2];
+    }
+
+    return caps;
+}
+
+const CPUCaps& GetCPUCaps() {
+    static CPUCaps caps = Detect();
+    return caps;
+}
+
+std::optional<int> GetProcessorCount() {
+#if defined(_WIN32)
+    // Get the buffer length.
+    DWORD length = 0;
+    GetLogicalProcessorInformation(nullptr, &length);
+    if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+        LOG_ERROR(Frontend, "Failed to query core count.");
+        return std::nullopt;
+    }
+    std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> buffer(
+        length / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
+    // Now query the core count.
+    if (!GetLogicalProcessorInformation(buffer.data(), &length)) {
+        LOG_ERROR(Frontend, "Failed to query core count.");
+        return std::nullopt;
+    }
+    return static_cast<int>(
+        std::count_if(buffer.cbegin(), buffer.cend(), [](const auto& proc_info) {
+            return proc_info.Relationship == RelationProcessorCore;
+        }));
+#elif defined(__unix__)
+    const int thread_count = std::thread::hardware_concurrency();
+    std::ifstream smt("/sys/devices/system/cpu/smt/active");
+    char state = '0';
+    if (smt) {
+        smt.read(&state, sizeof(state));
+    }
+    switch (state) {
+    case '0':
+        return thread_count;
+    case '1':
+        return thread_count / 2;
+    default:
+        return std::nullopt;
+    }
+#else
+    // Shame on you
+    return std::nullopt;
+#endif
+}
+
+} // namespace Common

--- a/src/yuzu_common/x64/cpu_detect.h
+++ b/src/yuzu_common/x64/cpu_detect.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
+// SPDX-FileCopyrightText: Copyright 2013 Dolphin Emulator Project / 2015 Citra Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <optional>
+#include <string_view>
+#include "yuzu_common/common_types.h"
+
+namespace Common {
+
+/// x86/x64 CPU capabilities that may be detected by this module
+struct CPUCaps {
+
+    enum class Manufacturer : u8 {
+        Unknown = 0,
+        Intel = 1,
+        AMD = 2,
+        Hygon = 3,
+    };
+
+    static Manufacturer ParseManufacturer(std::string_view brand_string);
+
+    Manufacturer manufacturer;
+    char brand_string[13];
+
+    char cpu_string[48];
+
+    u32 base_frequency;
+    u32 max_frequency;
+    u32 bus_frequency;
+
+    u32 tsc_crystal_ratio_denominator;
+    u32 tsc_crystal_ratio_numerator;
+    u32 crystal_frequency;
+    u64 tsc_frequency; // Derived from the above three values
+
+    bool sse : 1;
+    bool sse2 : 1;
+    bool sse3 : 1;
+    bool ssse3 : 1;
+    bool sse4_1 : 1;
+    bool sse4_2 : 1;
+
+    bool avx : 1;
+    bool avx_vnni : 1;
+    bool avx2 : 1;
+    bool avx512f : 1;
+    bool avx512dq : 1;
+    bool avx512cd : 1;
+    bool avx512bw : 1;
+    bool avx512vl : 1;
+    bool avx512vbmi : 1;
+    bool avx512bitalg : 1;
+
+    bool aes : 1;
+    bool bmi1 : 1;
+    bool bmi2 : 1;
+    bool f16c : 1;
+    bool fma : 1;
+    bool fma4 : 1;
+    bool gfni : 1;
+    bool invariant_tsc : 1;
+    bool lzcnt : 1;
+    bool monitorx : 1;
+    bool movbe : 1;
+    bool pclmulqdq : 1;
+    bool popcnt : 1;
+    bool sha : 1;
+    bool waitpkg : 1;
+};
+
+/**
+ * Gets the supported capabilities of the host CPU
+ * @return Reference to a CPUCaps struct with the detected host CPU capabilities
+ */
+const CPUCaps& GetCPUCaps();
+
+/// Detects CPU core count
+std::optional<int> GetProcessorCount();
+
+} // namespace Common

--- a/src/yuzu_common/x64/cpu_wait.cpp
+++ b/src/yuzu_common/x64/cpu_wait.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <thread>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+#include "yuzu_common/x64/cpu_detect.h"
+#include "yuzu_common/x64/cpu_wait.h"
+#include "yuzu_common/x64/rdtsc.h"
+
+namespace Common::X64 {
+
+namespace {
+
+// 100,000 cycles is a reasonable amount of time to wait to save on CPU resources.
+// For reference:
+// At 1 GHz, 100K cycles is 100us
+// At 2 GHz, 100K cycles is 50us
+// At 4 GHz, 100K cycles is 25us
+constexpr auto PauseCycles = 100'000U;
+
+} // Anonymous namespace
+
+#ifdef _MSC_VER
+__forceinline static void TPAUSE() {
+    static constexpr auto RequestC02State = 0U;
+    _tpause(RequestC02State, FencedRDTSC() + PauseCycles);
+}
+
+__forceinline static void MWAITX() {
+    static constexpr auto EnableWaitTimeFlag = 1U << 1;
+    static constexpr auto RequestC1State = 0U;
+
+    // monitor_var should be aligned to a cache line.
+    alignas(64) u64 monitor_var{};
+    _mm_monitorx(&monitor_var, 0, 0);
+    _mm_mwaitx(EnableWaitTimeFlag, RequestC1State, PauseCycles);
+}
+#else
+static void TPAUSE() {
+    static constexpr auto RequestC02State = 0U;
+    const auto tsc = FencedRDTSC() + PauseCycles;
+    const auto eax = static_cast<u32>(tsc & 0xFFFFFFFF);
+    const auto edx = static_cast<u32>(tsc >> 32);
+    asm volatile("tpause %0" : : "r"(RequestC02State), "d"(edx), "a"(eax));
+}
+
+static void MWAITX() {
+    static constexpr auto EnableWaitTimeFlag = 1U << 1;
+    static constexpr auto RequestC1State = 0U;
+
+    // monitor_var should be aligned to a cache line.
+    alignas(64) u64 monitor_var{};
+    asm volatile("monitorx" : : "a"(&monitor_var), "c"(0), "d"(0));
+    asm volatile("mwaitx" : : "a"(RequestC1State), "b"(PauseCycles), "c"(EnableWaitTimeFlag));
+}
+#endif
+
+void MicroSleep() {
+    static const bool has_waitpkg = GetCPUCaps().waitpkg;
+    static const bool has_monitorx = GetCPUCaps().monitorx;
+
+    if (has_waitpkg) {
+        TPAUSE();
+    } else if (has_monitorx) {
+        MWAITX();
+    } else {
+        std::this_thread::yield();
+    }
+}
+
+} // namespace Common::X64

--- a/src/yuzu_common/x64/cpu_wait.h
+++ b/src/yuzu_common/x64/cpu_wait.h
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace Common::X64 {
+
+void MicroSleep();
+
+} // namespace Common::X64

--- a/src/yuzu_common/x64/native_clock.cpp
+++ b/src/yuzu_common/x64/native_clock.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright 2020 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "yuzu_common/uint128.h"
+#include "yuzu_common/x64/native_clock.h"
+#include "yuzu_common/x64/rdtsc.h"
+
+namespace Common::X64 {
+
+NativeClock::NativeClock(u64 rdtsc_frequency_)
+    : rdtsc_frequency{rdtsc_frequency_}, ns_rdtsc_factor{GetFixedPoint64Factor(NsRatio::den,
+                                                                               rdtsc_frequency)},
+      us_rdtsc_factor{GetFixedPoint64Factor(UsRatio::den, rdtsc_frequency)},
+      ms_rdtsc_factor{GetFixedPoint64Factor(MsRatio::den, rdtsc_frequency)},
+      cntpct_rdtsc_factor{GetFixedPoint64Factor(CNTFRQ, rdtsc_frequency)},
+      gputick_rdtsc_factor{GetFixedPoint64Factor(GPUTickFreq, rdtsc_frequency)} {}
+
+std::chrono::nanoseconds NativeClock::GetTimeNS() const {
+    return std::chrono::nanoseconds{MultiplyHigh(GetUptime(), ns_rdtsc_factor)};
+}
+
+std::chrono::microseconds NativeClock::GetTimeUS() const {
+    return std::chrono::microseconds{MultiplyHigh(GetUptime(), us_rdtsc_factor)};
+}
+
+std::chrono::milliseconds NativeClock::GetTimeMS() const {
+    return std::chrono::milliseconds{MultiplyHigh(GetUptime(), ms_rdtsc_factor)};
+}
+
+s64 NativeClock::GetCNTPCT() const {
+    return MultiplyHigh(GetUptime(), cntpct_rdtsc_factor);
+}
+
+s64 NativeClock::GetGPUTick() const {
+    return MultiplyHigh(GetUptime(), gputick_rdtsc_factor);
+}
+
+s64 NativeClock::GetUptime() const {
+    return static_cast<s64>(FencedRDTSC());
+}
+
+bool NativeClock::IsNative() const {
+    return true;
+}
+
+} // namespace Common::X64

--- a/src/yuzu_common/x64/native_clock.h
+++ b/src/yuzu_common/x64/native_clock.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright 2020 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "yuzu_common/wall_clock.h"
+
+namespace Common::X64 {
+
+class NativeClock final : public WallClock {
+public:
+    explicit NativeClock(u64 rdtsc_frequency_);
+
+    std::chrono::nanoseconds GetTimeNS() const override;
+
+    std::chrono::microseconds GetTimeUS() const override;
+
+    std::chrono::milliseconds GetTimeMS() const override;
+
+    s64 GetCNTPCT() const override;
+
+    s64 GetGPUTick() const override;
+
+    s64 GetUptime() const override;
+
+    bool IsNative() const override;
+
+private:
+    u64 rdtsc_frequency;
+
+    u64 ns_rdtsc_factor;
+    u64 us_rdtsc_factor;
+    u64 ms_rdtsc_factor;
+    u64 cntpct_rdtsc_factor;
+    u64 gputick_rdtsc_factor;
+};
+
+} // namespace Common::X64

--- a/src/yuzu_common/x64/rdtsc.cpp
+++ b/src/yuzu_common/x64/rdtsc.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <thread>
+
+#include "yuzu_common/steady_clock.h"
+#include "yuzu_common/uint128.h"
+#include "yuzu_common/x64/rdtsc.h"
+
+namespace Common::X64 {
+
+template <u64 Nearest>
+static u64 RoundToNearest(u64 value) {
+    const auto mod = value % Nearest;
+    return mod >= (Nearest / 2) ? (value - mod + Nearest) : (value - mod);
+}
+
+u64 EstimateRDTSCFrequency() {
+    // Discard the first result measuring the rdtsc.
+    FencedRDTSC();
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    FencedRDTSC();
+
+    // Get the current time.
+    const auto start_time = RealTimeClock::Now();
+    const u64 tsc_start = FencedRDTSC();
+    // Wait for 100 milliseconds.
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    const auto end_time = RealTimeClock::Now();
+    const u64 tsc_end = FencedRDTSC();
+    // Calculate differences.
+    const u64 timer_diff = static_cast<u64>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count());
+    const u64 tsc_diff = tsc_end - tsc_start;
+    const u64 tsc_freq = MultiplyAndDivide64(tsc_diff, 1000000000ULL, timer_diff);
+    return RoundToNearest<100'000>(tsc_freq);
+}
+
+} // namespace Common::X64

--- a/src/yuzu_common/x64/rdtsc.h
+++ b/src/yuzu_common/x64/rdtsc.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright 2023 yuzu Emulator Project
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+#include "yuzu_common/common_types.h"
+
+namespace Common::X64 {
+
+#ifdef _MSC_VER
+__forceinline static u64 FencedRDTSC() {
+    _mm_lfence();
+    _ReadWriteBarrier();
+    const u64 result = __rdtsc();
+    _mm_lfence();
+    _ReadWriteBarrier();
+    return result;
+}
+#else
+static inline u64 FencedRDTSC() {
+    u64 eax;
+    u64 edx;
+    asm volatile("lfence\n\t"
+                 "rdtsc\n\t"
+                 "lfence\n\t"
+                 : "=a"(eax), "=d"(edx));
+    return (edx << 32) | eax;
+}
+#endif
+
+u64 EstimateRDTSCFrequency();
+
+} // namespace Common::X64

--- a/src/yuzu_common/yuzu_common.vcxproj
+++ b/src/yuzu_common/yuzu_common.vcxproj
@@ -122,12 +122,17 @@
     <ClInclude Include="tiny_mt.h" />
     <ClInclude Include="tree.h" />
     <ClInclude Include="typed_address.h" />
+    <ClInclude Include="uint128.h" />
     <ClInclude Include="unique_function.h" />
     <ClInclude Include="uuid.h" />
     <ClInclude Include="vector_math.h" />
     <ClInclude Include="virtual_buffer.h" />
     <ClInclude Include="wall_clock.h" />
     <ClInclude Include="windows\timer_resolution.h" />
+    <ClInclude Include="x64\cpu_detect.h" />
+    <ClInclude Include="x64\cpu_wait.h" />
+    <ClInclude Include="x64\native_clock.h" />
+    <ClInclude Include="x64\rdtsc.h" />
     <ClInclude Include="x64\xbyak_abi.h" />
     <ClInclude Include="x64\xbyak_util.h" />
     <ClInclude Include="yuzu_assert.h" />
@@ -169,6 +174,10 @@
     <ClCompile Include="virtual_buffer.cpp" />
     <ClCompile Include="wall_clock.cpp" />
     <ClCompile Include="windows\timer_resolution.cpp" />
+    <ClCompile Include="x64\cpu_detect.cpp" />
+    <ClCompile Include="x64\cpu_wait.cpp" />
+    <ClCompile Include="x64\native_clock.cpp" />
+    <ClCompile Include="x64\rdtsc.cpp" />
     <ClCompile Include="yuzu_assert.cpp" />
     <ClCompile Include="zstd_compression.cpp" />
   </ItemGroup>

--- a/src/yuzu_common/yuzu_common.vcxproj.filters
+++ b/src/yuzu_common/yuzu_common.vcxproj.filters
@@ -40,6 +40,9 @@
     <Filter Include="Source Files\android">
       <UniqueIdentifier>{0783a878-f07c-448f-8e53-8bedc1c8366a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\x64">
+      <UniqueIdentifier>{0074faf6-5e28-4a23-8bdf-a7ea6d8f25a6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="logging\backend.h">
@@ -342,6 +345,21 @@
     <ClInclude Include="android\java_bridge.h">
       <Filter>Header Files\android</Filter>
     </ClInclude>
+    <ClInclude Include="x64\cpu_detect.h">
+      <Filter>Header Files\x64</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\native_clock.h">
+      <Filter>Header Files\x64</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\rdtsc.h">
+      <Filter>Header Files\x64</Filter>
+    </ClInclude>
+    <ClInclude Include="x64\cpu_wait.h">
+      <Filter>Header Files\x64</Filter>
+    </ClInclude>
+    <ClInclude Include="uint128.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="logging\backend.cpp">
@@ -454,6 +472,18 @@
     </ClCompile>
     <ClCompile Include="fs\fs_android.cpp">
       <Filter>Source Files\fs</Filter>
+    </ClCompile>
+    <ClCompile Include="x64\cpu_detect.cpp">
+      <Filter>Source Files\x64</Filter>
+    </ClCompile>
+    <ClCompile Include="x64\native_clock.cpp">
+      <Filter>Source Files\x64</Filter>
+    </ClCompile>
+    <ClCompile Include="x64\rdtsc.cpp">
+      <Filter>Source Files\x64</Filter>
+    </ClCompile>
+    <ClCompile Include="x64\cpu_wait.cpp">
+      <Filter>Source Files\x64</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/yuzu_video_core/macro/macro.cpp
+++ b/src/yuzu_video_core/macro/macro.cpp
@@ -19,7 +19,7 @@
 #include "yuzu_video_core/macro/macro_hle.h"
 #include "yuzu_video_core/macro/macro_interpreter.h"
 
-#ifdef ARCHITECTURE_x86_64
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
 #include "yuzu_video_core/macro/macro_jit_x64.h"
 #endif
 
@@ -132,7 +132,7 @@ std::unique_ptr<MacroEngine> GetMacroEngine(Engines::Maxwell3D& maxwell3d) {
     if (Settings::values.disable_macro_jit) {
         return std::make_unique<MacroInterpreter>(maxwell3d);
     }
-#ifdef ARCHITECTURE_x86_64
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
     return std::make_unique<MacroJITx64>(maxwell3d);
 #else
     return std::make_unique<MacroInterpreter>(maxwell3d);


### PR DESCRIPTION
CreateOptimalClock() and the CoreTiming wait path are guarded by ARCHITECTURE_x86_64, which yuzu define at CMake configure time via DetectArchitecture.cmake. nxemu builds with MSVC vcxproj and never defines that macro, so those branches are never compiled in.

On x64 MSVC, the intended path is selected by compiler builtins such as _M_X64. Because the code checked the CMake macro instead, the #else path always ran: StandardWallClock (via system_clock::now()) and std::this_thread::yield() instead of NativeClock and MicroSleep. The related x64 sources were also not part of the vcxproj build, so even a corrected guard would have had nothing to call.