### PR TITLE
NCE should always be on

### DIFF
--- a/src/nxemu-cpu/arm_dynarmic_32.cpp
+++ b/src/nxemu-cpu/arm_dynarmic_32.cpp
@@ -234,7 +234,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ArmDynarmic32::MakeJit(IKernelProcess & proc
     config.enable_cycle_counting = !m_uses_wall_clock;
 
     // Code cache size
-#ifdef ARCHITECTURE_arm64
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     config.code_cache_size = 128_MiB;
 #else
     config.code_cache_size = 512_MiB;

--- a/src/nxemu-cpu/arm_dynarmic_64.cpp
+++ b/src/nxemu-cpu/arm_dynarmic_64.cpp
@@ -291,7 +291,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ArmDynarmic64::MakeJit(IKernelProcess & proc
     config.enable_cycle_counting = !m_uses_wall_clock;
 
     // Code cache size
-#ifdef ARCHITECTURE_arm64
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     config.code_cache_size = 128_MiB;
 #else
     config.code_cache_size = 512_MiB;

--- a/src/nxemu-cpu/cpu_manager.cpp
+++ b/src/nxemu-cpu/cpu_manager.cpp
@@ -5,7 +5,7 @@
 #include "arm_dynarmic_64.h"
 #include "arm_dynarmic_32.h"
 #include "patch/patch_collection.h"
-#if defined(_M_X64) || defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_arm64)
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64) || defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
 #include "exclusive_monitor_interface.h"
 #endif
 
@@ -28,7 +28,7 @@ bool CpuInterface::Initialize(void)
 
 IExclusiveMonitor * CpuInterface::CreateExclusiveMonitor(IMemory & memory)
 {
-#if defined(_M_X64) || defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_arm64)
+#if defined(_M_X64) || defined(ARCHITECTURE_x86_64) || defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     return new ExclusiveMonitor(memory, m_monitor);
 #else
     // TODO(merry): Passthrough exclusive monitor
@@ -43,7 +43,7 @@ IPatchCollection * CpuInterface::CreatePatchCollection(bool is_application)
 
 ICpuCore * CpuInterface::CreateCpuCore(ICoreSystem & system, bool is64Bit, bool usesWallClock, IKernelProcess & process, uint32_t coreIndex)
 {
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     if (this->IsApplication() && g_settings->GetBool(NXCpuSetting::NceEnabled))
     {
         // Register the scoped JIT handler before creating any NCE instances

--- a/src/nxemu-cpu/cpu_settings.cpp
+++ b/src/nxemu-cpu/cpu_settings.cpp
@@ -49,7 +49,7 @@ public:
 };
 
 static CpuSetting settings[] = {
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     {NXCpuSetting::CpuBackend, "cpu", "cpu_backend", &cpuSettings.cpu_backend, CpuBackend::Nce},
 #else
     {NXCpuSetting::CpuBackend, "cpu", "cpu_backend", &cpuSettings.cpu_backend, CpuBackend::Dynarmic},

--- a/src/nxemu-cpu/dynarmic_cp15.cpp
+++ b/src/nxemu-cpu/dynarmic_cp15.cpp
@@ -61,7 +61,7 @@ CallbackOrAccessOneWord DynarmicCP15::CompileSendOneWord(bool two, unsigned opc1
                     _mm_lfence();
 #elif defined(_M_X64) || defined(ARCHITECTURE_x86_64)
                     asm volatile("mfence\n\tlfence\n\t" : : : "memory");
-#elif defined(ARCHITECTURE_arm64)
+#elif defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
                     asm volatile("dsb sy\n\t" : : : "memory");
 #else
 #error Unsupported architecture
@@ -78,7 +78,7 @@ CallbackOrAccessOneWord DynarmicCP15::CompileSendOneWord(bool two, unsigned opc1
                     _mm_mfence();
 #elif defined(_M_X64) || defined(ARCHITECTURE_x86_64)
                     asm volatile("mfence\n\t" : : : "memory");
-#elif defined(ARCHITECTURE_arm64)
+#elif defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
                     asm volatile("dmb sy\n\t" : : : "memory");
 #else
 #error Unsupported architecture

--- a/src/nxemu-cpu/patch/patch_collection.cpp
+++ b/src/nxemu-cpu/patch/patch_collection.cpp
@@ -5,14 +5,14 @@ PatchCollection::PatchCollection(ISystemModules & modules, bool is_application) 
     m_is_application(is_application)
 {
     std::fill(std::begin(m_module_patcher_indices), std::end(m_module_patcher_indices), -1);
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
     m_patchers.emplace_back();
 #endif
 }
 
 void PatchCollection::PatchText(int32_t patch_index, const uint8_t * program_image, uint32_t image_size, uint32_t code_offset, uint32_t code_size)
 {
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
     if (!g_settings->GetBool(NXCpuSetting::NceEnabled))
     {
         return;
@@ -34,7 +34,7 @@ void PatchCollection::PatchText(int32_t patch_index, const uint8_t * program_ima
 
 void PatchCollection::Relocate(int32_t patch_index, uint64_t load_base, uint8_t * program_image, uint32_t * image_size, uint32_t code_offset, uint32_t code_size, uint64_t * segment_addr, uint32_t * segment_size)
 {
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
     if (!g_settings->GetBool(NXCpuSetting::NceEnabled))
     {
         return;
@@ -82,7 +82,7 @@ void PatchCollection::Relocate(int32_t patch_index, uint64_t load_base, uint8_t 
 
 uint32_t PatchCollection::GetTotalPatchSize() const
 {
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
     if (!g_settings->GetBool(NXCpuSetting::NceEnabled))
     {
         return 0;
@@ -101,7 +101,7 @@ uint32_t PatchCollection::GetTotalPatchSize() const
 
 uint32_t PatchCollection::GetPreTextSize(int32_t patch_index) const
 {
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
     if (!g_settings->GetBool(NXCpuSetting::NceEnabled))
     {
         return 0;
@@ -125,7 +125,7 @@ uint32_t PatchCollection::GetPreTextSize(int32_t patch_index) const
 
 int32_t PatchCollection::GetLastIndex() const
 {
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
     return (int32_t)(m_patchers.size()) - 1;
 #else
     return 0;

--- a/src/nxemu-cpu/patch/patch_collection.h
+++ b/src/nxemu-cpu/patch/patch_collection.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <nxemu-module-spec/cpu.h>
 
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
 #undef NOMINMAX
 #include "nce/patcher.h"
 #endif
@@ -25,7 +25,7 @@ private:
     ISystemModules & m_modules;
     bool m_is_application;
     int32_t m_module_patcher_indices[13];
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
     std::vector<Core::NCE::Patcher> m_patchers;
 #endif
 };

--- a/src/nxemu-loader/core/loader/nro.cpp
+++ b/src/nxemu-loader/core/loader/nro.cpp
@@ -26,7 +26,7 @@
 #include "core/loader/nso.h"
 #include "core/memory.h"
 
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
 #include "core/arm/nce/patcher.h"
 #endif
 
@@ -223,7 +223,7 @@ static bool LoadNroImpl(Systemloader & loader, ISystemModules & modules, const s
     program_image.resize(static_cast<u32>(program_image.size()) + bss_size);
     size_t image_size = program_image.size();
 
-#ifdef HAS_NCE
+#ifdef defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     const auto& code = codeset.CodeSegment();
 
     // NROs always have a 39-bit address space.
@@ -268,7 +268,7 @@ static bool LoadNroImpl(Systemloader & loader, ISystemModules & modules, const s
 
     // Relocate code patch and copy to the program_image if running under NCE.
     // This needs to be after LoadFromMetadata so we can use the process entry point.
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     if (g_settings->GetBool(NXCpuSetting::NceEnabled)) {
         patch.RelocateAndCopy(process.GetEntryPoint(), code, program_image,
                               &process.GetPostHandlers());

--- a/src/nxemu-os/core/device_memory.cpp
+++ b/src/nxemu-os/core/device_memory.cpp
@@ -6,7 +6,7 @@
 
 namespace Core {
 
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
 constexpr size_t VirtualReserveSize = 1ULL << 38;
 #else
 constexpr size_t VirtualReserveSize = 1ULL << 39;

--- a/src/nxemu-os/core/hle/kernel/code_set.h
+++ b/src/nxemu-os/core/hle/kernel/code_set.h
@@ -75,7 +75,7 @@ struct CodeSet final {
         return segments[2];
     }
 
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     Segment& PatchSegment() {
         return patch_segment;
     }
@@ -91,7 +91,7 @@ struct CodeSet final {
     /// The segments that comprise this code set.
     std::array<Segment, 3> segments;
 
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     Segment patch_segment;
 #endif
 

--- a/src/nxemu-os/core/hle/kernel/k_address_space_info.cpp
+++ b/src/nxemu-os/core/hle/kernel/k_address_space_info.cpp
@@ -25,7 +25,7 @@ constexpr std::array<KAddressSpaceInfo, 13> AddressSpaceInfos{{
    { .bit_width = 36, .address = 2_GiB       , .size = 64_GiB  - 2_GiB  , .type = KAddressSpaceInfo::Type::MapLarge, },
    { .bit_width = 36, .address = Size_Invalid, .size = 8_GiB            , .type = KAddressSpaceInfo::Type::Heap,     },
    { .bit_width = 36, .address = Size_Invalid, .size = 6_GiB            , .type = KAddressSpaceInfo::Type::Alias,    },
-#if defined(ARCHITECTURE_arm64) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64) || defined(__aarch64__)
    // With NCE, we use a 38-bit address space due to memory limitations. This should (safely) truncate ASLR region.
    { .bit_width = 39, .address = 128_MiB     , .size = 256_GiB - 128_MiB, .type = KAddressSpaceInfo::Type::Map39Bit, },
 #else

--- a/src/nxemu-os/core/hle/kernel/k_page_table_base.cpp
+++ b/src/nxemu-os/core/hle/kernel/k_page_table_base.cpp
@@ -125,7 +125,7 @@ constexpr Common::MemoryPermission ConvertToMemoryPermission(KMemoryPermission p
     {
         perms |= Common::MemoryPermission::Write;
     }
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     if (True(perm & KMemoryPermission::UserExecute))
     {
         perms |= Common::MemoryPermission::Execute;

--- a/src/nxemu-os/core/hle/kernel/k_process.cpp
+++ b/src/nxemu-os/core/hle/kernel/k_process.cpp
@@ -1400,7 +1400,7 @@ void KProcess::LoadModule(const IModuleInfo & module, KProcessAddress base_addr)
     m_page_table.SetProcessMemoryPermission((KProcessAddress)(module.RODataSegmentAddr()) + base_addr, module.RODataSegmentSize(), Svc::MemoryPermission::Read);
     m_page_table.SetProcessMemoryPermission((KProcessAddress)(module.DataSegmentAddr()) + base_addr, module.DataSegmentSize(), Svc::MemoryPermission::ReadWrite);
 
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     const auto & patch = code_set.PatchSegment();
     if (this->IsApplication() && g_settings->GetBool(NXCpuSetting::NceEnabled) && patch.size != 0)
     {

--- a/src/nxemu-os/core/hle/kernel/k_process.h
+++ b/src/nxemu-os/core/hle/kernel/k_process.h
@@ -136,7 +136,7 @@ private:
     std::atomic<s64> m_num_ipc_messages{};
     std::atomic<s64> m_num_ipc_replies{};
     std::atomic<s64> m_num_ipc_receives{};
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     std::unordered_map<u64, u64> m_post_handlers{};
 #endif
     ExclusiveMonitorPtr m_exclusive_monitor;
@@ -558,7 +558,7 @@ public:
 
     static void Switch(KProcess* cur_process, KProcess* next_process);
 
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     std::unordered_map<u64, u64>& GetPostHandlers() noexcept {
         return m_post_handlers;
     }

--- a/src/nxemu-video/render_window.cpp
+++ b/src/nxemu-video/render_window.cpp
@@ -12,7 +12,7 @@
 #include <dlfcn.h>
 #include <nxemu-core/settings/identifiers.h>
 #include <yuzu_common/dynamic_library.h>
-#ifdef ARCHITECTURE_arm64
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
 #include <adrenotools/driver.h>
 #endif
 #endif
@@ -266,7 +266,7 @@ std::shared_ptr<Common::DynamicLibrary> LoadAndroidVulkanDriverFromSettings()
     const std::string custom_driver_name = g_settings->GetString(NXCoreSetting::GpuCustomDriverName);
     const std::string file_redirect_dir = g_settings->GetString(NXCoreSetting::GpuFileRedirectDir);
 
-#ifdef ARCHITECTURE_arm64
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     void * handle{};
     const char * file_redirect_dir_ptr{};
     int feature_flags{};

--- a/src/yuzu_common/common_funcs.h
+++ b/src/yuzu_common/common_funcs.h
@@ -33,7 +33,7 @@
 
 #if defined(_M_X64) || defined(ARCHITECTURE_x86_64)
 #define Crash() __asm__ __volatile__("int $3")
-#elif defined(ARCHITECTURE_arm64)
+#elif defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
 #define Crash() __asm__ __volatile__("brk #0")
 #else
 #define Crash() exit(1)

--- a/src/yuzu_common/host_memory.cpp
+++ b/src/yuzu_common/host_memory.cpp
@@ -369,7 +369,7 @@ private:
 
 #elif defined(__linux__) || defined(__FreeBSD__) // ^^^ Windows ^^^ vvv Linux vvv
 
-#ifdef ARCHITECTURE_arm64
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
 
 static void* ChooseVirtualBase(size_t virtual_size) {
     constexpr uintptr_t Map39BitSize = (1ULL << 39);
@@ -510,7 +510,7 @@ public:
         if (True(perms & MemoryPermission::Write)) {
             flags |= PROT_WRITE;
         }
-#ifdef ARCHITECTURE_arm64
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
         if (True(perms & MemoryPermission::Execute)) {
             flags |= PROT_EXEC;
         }
@@ -548,7 +548,7 @@ public:
         if (write) {
             flags |= PROT_WRITE;
         }
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
         if (execute) {
             flags |= PROT_EXEC;
         }

--- a/src/yuzu_common/wall_clock.cpp
+++ b/src/yuzu_common/wall_clock.cpp
@@ -10,7 +10,7 @@
 #include "yuzu_common/x64/rdtsc.h"
 #endif
 
-#ifdef HAS_NCE
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
 #include "yuzu_common/arm64/native_clock.h"
 #endif
 
@@ -66,7 +66,7 @@ std::unique_ptr<WallClock> CreateOptimalClock() {
         // - Is not more precise than 1 GHz (1ns resolution)
         return std::make_unique<StandardWallClock>();
     }
-#elif defined(HAS_NCE)
+#elif defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
     return std::make_unique<Arm64::NativeClock>();
 #else
     return std::make_unique<StandardWallClock>();

--- a/src/yuzu_video_core/renderer_vulkan/vk_turbo_mode.cpp
+++ b/src/yuzu_video_core/renderer_vulkan/vk_turbo_mode.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2022 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#if defined(ANDROID) && defined(ARCHITECTURE_arm64)
+#if defined(ANDROID) && (defined(_M_ARM64) || defined(ARCHITECTURE_arm64))
 #include <adrenotools/driver.h>
 #endif
 
@@ -152,7 +152,7 @@ void TurboMode::Run(std::stop_token stop_token) {
 
     while (!stop_token.stop_requested()) {
 #ifdef ANDROID
-#ifdef ARCHITECTURE_arm64
+#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)
         adrenotools_set_turbo(true);
 #endif
 #else
@@ -229,7 +229,7 @@ void TurboMode::Run(std::stop_token stop_token) {
                    std::chrono::milliseconds{100};
         });
     }
-#if defined(ANDROID) && defined(ARCHITECTURE_arm64)
+#if defined(ANDROID) && (defined(_M_ARM64) || defined(ARCHITECTURE_arm64))
     adrenotools_set_turbo(false);
 #endif
 }

--- a/src/yuzu_video_core/vulkan_common/vulkan_device.cpp
+++ b/src/yuzu_video_core/vulkan_common/vulkan_device.cpp
@@ -20,7 +20,7 @@
 #include "yuzu_video_core/vulkan_common/vulkan_device.h"
 #include "yuzu_video_core/vulkan_common/vulkan_wrapper.h"
 
-#if defined(ANDROID) && defined(ARCHITECTURE_arm64)
+#if defined(ANDROID) && (defined(_M_ARM64) || defined(ARCHITECTURE_arm64))
 #include <adrenotools/bcenabler.h>
 #endif
 
@@ -289,7 +289,7 @@ std::unordered_map<VkFormat, VkFormatProperties> GetFormatProperties(vk::Physica
     return format_properties;
 }
 
-#if defined(ANDROID) && defined(ARCHITECTURE_arm64)
+#if defined(ANDROID) && (defined(_M_ARM64) || defined(ARCHITECTURE_arm64))
 void OverrideBcnFormats(std::unordered_map<VkFormat, VkFormatProperties> & format_properties)
 {
     // These properties are extracted from Adreno driver 512.687.0
@@ -535,7 +535,7 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
                     "Qualcomm drivers have a slow VK_KHR_push_descriptor implementation");
         RemoveExtension(extensions.push_descriptor, VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
 
-#if defined(ANDROID) && defined(ARCHITECTURE_arm64)
+#if defined(ANDROID) && (defined(_M_ARM64) || defined(ARCHITECTURE_arm64))
         // Patch the driver to enable BCn textures.
         const auto major = (properties.properties.driverVersion >> 24) << 2;
         const auto minor = (properties.properties.driverVersion >> 12) & 0xFFFU;

--- a/src/yuzu_video_core/vulkan_common/vulkan_library.cpp
+++ b/src/yuzu_video_core/vulkan_common/vulkan_library.cpp
@@ -13,7 +13,7 @@ namespace Vulkan {
 std::shared_ptr<Common::DynamicLibrary> OpenLibrary(
     [[maybe_unused]] Core::Frontend::GraphicsContext* context) {
     LOG_DEBUG(Render_Vulkan, "Looking for a Vulkan library");
-#if defined(ANDROID) && defined(ARCHITECTURE_arm64)
+#if defined(ANDROID) && (defined(_M_ARM64) || defined(ARCHITECTURE_arm64))
     // Android manages its Vulkan driver from the frontend.
     return context->GetDriverLibrary();
 #else


### PR DESCRIPTION
Update how define for arm64 is used, NCE should always be on when on arm64

eg.
#if defined(_M_ARM64) || defined(ARCHITECTURE_arm64)