### PR TITLE
OS: if bis_system.GetEntry(FirmwareVersionSystemDataId, LoaderContent…

### DIFF
--- a/src/nxemu-os/core/hle/service/set/system_settings_server.cpp
+++ b/src/nxemu-os/core/hle/service/set/system_settings_server.cpp
@@ -48,7 +48,11 @@ Result GetFirmwareVersionImpl(FirmwareVersionFormat & out_firmware, Core::System
     FileSysNCAPtr nca = bis_system.GetEntry(FirmwareVersionSystemDataId, LoaderContentRecordType::Data);
     if (nca)
     {
-        UNIMPLEMENTED();
+        IVirtualFilePtr nca_romfs(nca->GetRomFS());
+        if (nca_romfs)
+        {
+            romfs = nca_romfs->ExtractRomFS();
+        }
     }
     if (!romfs)
     {


### PR DESCRIPTION
…RecordType::Data) works then load its romfs