### PR TITLE
controller config: fix opacity bug

### DIFF
--- a/lang/english/html/input_config.html
+++ b/lang/english/html/input_config.html
@@ -120,8 +120,7 @@ div.center-bottom-row
   width: max-content;
 }
 
-.controller-config .group.vibration:disabled,
-.controller-config .group.vibration:disabled *
+.controller-config .group.vibration:disabled
 {
   opacity: 0.45;
   cursor: default;


### PR DESCRIPTION
the vibration disabled was giving everything an opacity of 0.45, fix it up so it only applies to the vibration group