### PR TITLE
OS: implement ExecuteProgram relaunch and application Exit handling

### DIFF
--- a/src/nxemu-loader/system_loader.cpp
+++ b/src/nxemu-loader/system_loader.cpp
@@ -542,13 +542,13 @@ bool Systemloader::SelectAndLoad(void * parentWindow)
     {
         return false;
     }
-    return LoadRom(fileName.c_str());
+    return LoadRom(fileName.c_str(), 0, -1, ApplicationLaunchType::FrontendInitiated);
 #else
     return false;
 #endif
 }
 
-bool Systemloader::LoadRom(const char * fileName)
+bool Systemloader::LoadRom(const char * fileName, int32_t program_index, int32_t previous_program_index, ApplicationLaunchType launch_type)
 {
     if (fileName == nullptr || fileName[0] == '\0')
     {
@@ -558,7 +558,7 @@ bool Systemloader::LoadRom(const char * fileName)
     impl->PrepareFirmwareForLoad(fileName);
     g_settings->SetInt(NXCoreSetting::EmulationState, (int32_t)EmulationState::LoadingRom);
     impl->m_file = Core::GetGameFileFromPath(impl->m_virtualFilesystem, fileName);
-    impl->m_appLoader = Loader::GetLoader(*this, impl->m_file, 0, 0);
+    impl->m_appLoader = Loader::GetLoader(*this, impl->m_file, 0, program_index);
     if (!impl->m_appLoader)
     {
         g_notify->DisplayError("The file format is not supported.", "Error loading file!");
@@ -603,6 +603,9 @@ bool Systemloader::LoadRom(const char * fileName)
         LOG_ERROR(Core, "Failed to read title for ROM!");
     }
 
+    IOperatingSystem & operatingSystem = impl->m_modules.OperatingSystem();
+    operatingSystem.SetApplicationLaunchParameters(program_index, previous_program_index, launch_type);
+
     const auto [load_result, load_parameters] = app_loader->Load(*this, impl->m_modules);
     if (load_result != LoaderResultStatus::Success)
     {
@@ -633,7 +636,6 @@ bool Systemloader::LoadRom(const char * fileName)
     StorageId baseGameStorageId = GetStorageIdForFrontendSlot(impl->m_contentProvider->GetSlotForEntry(impl->m_titleID, LoaderContentRecordType::Program));
     StorageId updateStorageId = GetStorageIdForFrontendSlot(impl->m_contentProvider->GetSlotForEntry(FileSys::GetUpdateTitleID(impl->m_titleID), LoaderContentRecordType::Program));
 
-    IOperatingSystem & operatingSystem = impl->m_modules.OperatingSystem();
     operatingSystem.StartApplicationProcess(load_parameters->main_thread_priority, load_parameters->main_thread_stack_size, version, baseGameStorageId, updateStorageId, nacp_data.data(), (uint32_t)nacp_data.size());
     return true;
 }

--- a/src/nxemu-loader/system_loader.h
+++ b/src/nxemu-loader/system_loader.h
@@ -29,7 +29,7 @@ public:
     //ISystemloader
     bool Initialize() override;
     bool SelectAndLoad(void * parentWindow) override;
-    bool LoadRom(const char * fileName) override;
+    bool LoadRom(const char * fileName, int32_t program_index, int32_t previous_program_index, ApplicationLaunchType launch_type) override;
     IRomInfo * RomInfo(const char * fileName, uint64_t programId, uint64_t programIndex) override;
     IRomInfo * FileRomInfo(IVirtualFile * file, uint64_t programId, uint64_t programIndex) override;
     IRomInfo * LoadedRomInfo() override;

--- a/src/nxemu-module-spec/base.h
+++ b/src/nxemu-module-spec/base.h
@@ -26,10 +26,10 @@
 
 enum
 {
-    MODULE_LOADER_SPECS_VERSION = 0x0129,
+    MODULE_LOADER_SPECS_VERSION = 0x012A,
     MODULE_VIDEO_SPECS_VERSION = 0x011D,
     MODULE_CPU_SPECS_VERSION = 0x0112,
-    MODULE_OPERATING_SYSTEM_SPECS_VERSION = 0x011A,
+    MODULE_OPERATING_SYSTEM_SPECS_VERSION = 0x011B,
 };
 
 enum MODULE_TYPE : uint16_t
@@ -300,6 +300,12 @@ nxinterface ISystemModules
     virtual IOperatingSystem & OperatingSystem() = 0;
     virtual IVideo & Video() = 0;
     virtual ICpu & Cpu() = 0;
+};
+
+enum class ApplicationLaunchType : uint32_t
+{
+    FrontendInitiated = 0,
+    ApplicationInitiated = 1,
 };
 
 /*

--- a/src/nxemu-module-spec/operating_system.h
+++ b/src/nxemu-module-spec/operating_system.h
@@ -520,6 +520,9 @@ nxinterface ICacheInvalidator
 };
 
 typedef void (*DeviceEnumCallback)(const char * device, void * userData);
+typedef void (*ExecuteProgramCallback)(size_t program_index, void * userData);
+typedef void (*ExitCallback)(void * userData);
+typedef void (*UserChannelEntryCallback)(const uint8_t * data, uint32_t size, void * userData);
 
 nxinterface IParamPackage
 {
@@ -705,6 +708,11 @@ nxinterface IOperatingSystem
     virtual bool RemoveProfile(const uint8_t uuid[HOST_PROFILE_UUID_SIZE]) = 0;
     virtual bool SetProfileImage(const uint8_t uuid[HOST_PROFILE_UUID_SIZE], const uint8_t * image_data, uint32_t image_size) = 0;
     virtual bool GetProfileImagePath(const uint8_t uuid[HOST_PROFILE_UUID_SIZE], char * out_path, uint32_t out_path_size) const = 0;
+    virtual void SetApplicationLaunchParameters(int32_t program_index, int32_t previous_program_index, ApplicationLaunchType launch_type) = 0;
+    virtual void RegisterExecuteProgramCallback(ExecuteProgramCallback callback, void * userData) = 0;
+    virtual void RegisterExitCallback(ExitCallback callback, void * userData) = 0;
+    virtual void ExportUserChannel(UserChannelEntryCallback callback, void * userData) = 0;
+    virtual void PushUserChannelEntry(const uint8_t * data, uint32_t size) = 0;
 };
 
 EXPORT IOperatingSystem * CALL CreateOperatingSystem(ISystemModules & modules);

--- a/src/nxemu-module-spec/system_loader.h
+++ b/src/nxemu-module-spec/system_loader.h
@@ -329,7 +329,7 @@ nxinterface ISystemloader
 {
     virtual bool Initialize() = 0;
     virtual bool SelectAndLoad(void * parentWindow) = 0;
-    virtual bool LoadRom(const char * fileName) = 0;
+    virtual bool LoadRom(const char * fileName, int32_t program_index, int32_t previous_program_index, ApplicationLaunchType launch_type) = 0;
     virtual IRomInfo * RomInfo(const char * fileName, uint64_t programId, uint64_t programIndex) = 0;
     virtual IRomInfo * FileRomInfo(IVirtualFile * file, uint64_t programId, uint64_t programIndex) = 0;
     virtual IRomInfo * LoadedRomInfo() = 0;

--- a/src/nxemu-os/core/core.cpp
+++ b/src/nxemu-os/core/core.cpp
@@ -269,7 +269,10 @@ struct System::Impl {
     bool is_multicore{};
     bool is_async_gpu{};
 
-    ExecuteProgramCallback execute_program_callback;
+    ::ExecuteProgramCallback execute_program_callback{};
+    void * execute_program_user_data{};
+    ::ExitCallback exit_callback{};
+    void * exit_user_data{};
     std::stop_source stop_event;
 
     std::array<Core::GPUDirtyMemoryManager, Hardware::NUM_CPU_CORES>
@@ -684,16 +687,17 @@ void System::RunServer(std::unique_ptr<Service::ServerManager> && server_manager
     return impl->kernel.RunServer(std::move(server_manager));
 }
 
-void System::RegisterExecuteProgramCallback(ExecuteProgramCallback && callback)
+void System::RegisterExecuteProgramCallback(::ExecuteProgramCallback callback, void * userData)
 {
-    impl->execute_program_callback = std::move(callback);
+    impl->execute_program_callback = callback;
+    impl->execute_program_user_data = userData;
 }
 
 void System::ExecuteProgram(std::size_t program_index)
 {
     if (impl->execute_program_callback)
     {
-        impl->execute_program_callback(program_index);
+        impl->execute_program_callback(program_index, impl->execute_program_user_data);
     }
     else
     {
@@ -706,10 +710,22 @@ std::deque<std::vector<u8>> & System::GetUserChannel()
     return impl->user_channel;
 }
 
+void System::RegisterExitCallback(::ExitCallback callback, void * userData)
+{
+    impl->exit_callback = callback;
+    impl->exit_user_data = userData;
+}
 
 void System::Exit()
 {
-    UNIMPLEMENTED();
+    if (impl->exit_callback)
+    {
+        impl->exit_callback(impl->exit_user_data);
+    }
+    else
+    {
+        LOG_CRITICAL(Core, "exit_callback must be initialized by the frontend");
+    }
 }
 
 } // namespace Core

--- a/src/nxemu-os/core/core.h
+++ b/src/nxemu-os/core/core.h
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 #include <deque>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <span>
@@ -384,16 +383,13 @@ public:
     /// Runs a server instance until shutdown.
     void RunServer(std::unique_ptr<Service::ServerManager> && server_manager);
 
-    /// Type used for the frontend to designate a callback for System to re-launch the application
-    /// using a specified program index.
-    using ExecuteProgramCallback = std::function<void(std::size_t)>;
-
     /**
      * Registers a callback from the frontend for System to re-launch the application using a
      * specified program index.
      * @param callback Callback from the frontend to relaunch the application.
+     * @param userData Opaque pointer passed back to the callback.
      */
-    void RegisterExecuteProgramCallback(ExecuteProgramCallback && callback);
+    void RegisterExecuteProgramCallback(::ExecuteProgramCallback callback, void * userData);
 
     /**
      * Instructs the frontend to re-launch the application using the specified program_index.
@@ -407,14 +403,12 @@ public:
      */
     [[nodiscard]] std::deque<std::vector<u8>> & GetUserChannel();
 
-    /// Type used for the frontend to designate a callback for System to exit the application.
-    using ExitCallback = std::function<void()>;
-
     /**
      * Registers a callback from the frontend for System to exit the application.
      * @param callback Callback from the frontend to exit the application.
+     * @param userData Opaque pointer passed back to the callback.
      */
-    void RegisterExitCallback(ExitCallback && callback);
+    void RegisterExitCallback(::ExitCallback callback, void * userData);
 
     /// Instructs the frontend to exit the application.
     void Exit();

--- a/src/nxemu-os/core/hle/service/am/service/application_functions.cpp
+++ b/src/nxemu-os/core/hle/service/am/service/application_functions.cpp
@@ -389,7 +389,7 @@ Result IApplicationFunctions::QueryApplicationPlayStatisticsByUid(Out<s32> out_e
 
 Result IApplicationFunctions::ExecuteProgram(ProgramSpecifyKind kind, u64 value)
 {
-    LOG_WARNING(Service_AM, "(STUBBED) called, kind={}, value={}", kind, value);
+    LOG_DEBUG(Service_AM, "called, kind={}, value={}", kind, value);
     ASSERT(kind == ProgramSpecifyKind::ExecuteProgram || kind == ProgramSpecifyKind::RestartProgram);
 
     // Copy user channel ownership into the system so that it will be preserved

--- a/src/nxemu-os/emu_thread.cpp
+++ b/src/nxemu-os/emu_thread.cpp
@@ -109,6 +109,7 @@ void EmuThread::Stop()
     impl->m_stop_source.request_stop();
     {
         std::lock_guard<std::mutex> lk{impl->m_should_run_mutex};
+        impl->m_should_run.store(false, std::memory_order_release);
         impl->m_should_run_cv.notify_one();
     }
 }

--- a/src/nxemu-os/os_manager.cpp
+++ b/src/nxemu-os/os_manager.cpp
@@ -133,7 +133,10 @@ extern IModuleSettings * g_settings;
 OSManager::OSManager(ISystemModules & modules) :
     m_modules(modules),
     m_coreSystem(modules),
-    m_applicationProcess(nullptr)
+    m_applicationProcess(nullptr),
+    m_programIndex(0),
+    m_previousProgramIndex(-1),
+    m_launchType(ApplicationLaunchType::FrontendInitiated)
 {
 }
 
@@ -161,6 +164,12 @@ void OSManager::EmulationStopping(bool wait)
 
     if (m_emuThread)
     {
+        m_coreSystem.SetShuttingDown(true);
+        if (m_coreSystem.IsPoweredOn())
+        {
+            m_coreSystem.SetExitRequested(true);
+            m_coreSystem.GetAppletManager().RequestExit();
+        }
         m_emuThread->Stop();
         if (wait)
         {
@@ -250,10 +259,18 @@ bool OSManager::CreateApplicationProcess(uint64_t codeSize, const IProgramMetada
     auto params = Service::AM::FrontendAppletParameters{
         .applet_id = Service::AM::AppletId::Application,
         .applet_type = Service::AM::AppletType::Application,
-        .launch_type = Service::AM::LaunchType::FrontendInitiated,
+        .launch_type = m_launchType == ApplicationLaunchType::ApplicationInitiated
+                           ? Service::AM::LaunchType::ApplicationInitiated
+                           : Service::AM::LaunchType::FrontendInitiated,
+        .program_index = m_programIndex,
+        .previous_program_index = m_previousProgramIndex,
     };
     params.program_id = metaData.GetTitleID();
     m_coreSystem.GetAppletManager().CreateAndInsertByFrontendAppletParameters(m_applicationProcess->GetProcessId(), params);
+
+    m_programIndex = 0;
+    m_previousProgramIndex = -1;
+    m_launchType = ApplicationLaunchType::FrontendInitiated;
 
     processID = m_applicationProcess->GetProcessId();
     baseAddress = GetInteger(m_applicationProcess->GetEntryPoint());
@@ -633,4 +650,43 @@ bool OSManager::GetProfileImagePath(const uint8_t uuid_bytes[HOST_PROFILE_UUID_S
 
     std::memcpy(out_path, path.c_str(), path.size() + 1);
     return true;
+}
+
+void OSManager::SetApplicationLaunchParameters(int32_t program_index, int32_t previous_program_index, ApplicationLaunchType launch_type)
+{
+    m_programIndex = program_index;
+    m_previousProgramIndex = previous_program_index;
+    m_launchType = launch_type;
+}
+
+void OSManager::RegisterExecuteProgramCallback(ExecuteProgramCallback callback, void * userData)
+{
+    m_coreSystem.RegisterExecuteProgramCallback(callback, userData);
+}
+
+void OSManager::RegisterExitCallback(ExitCallback callback, void * userData)
+{
+    m_coreSystem.RegisterExitCallback(callback, userData);
+}
+
+void OSManager::ExportUserChannel(UserChannelEntryCallback callback, void * userData)
+{
+    if (callback == nullptr)
+    {
+        return;
+    }
+    for (const auto & entry : m_coreSystem.GetUserChannel())
+    {
+        callback(entry.data(), (uint32_t)entry.size(), userData);
+    }
+}
+
+void OSManager::PushUserChannelEntry(const uint8_t * data, uint32_t size)
+{
+    if (data == nullptr || size == 0)
+    {
+        m_coreSystem.GetUserChannel().emplace_back();
+        return;
+    }
+    m_coreSystem.GetUserChannel().emplace_back(data, data + size);
 }

--- a/src/nxemu-os/os_manager.h
+++ b/src/nxemu-os/os_manager.h
@@ -58,6 +58,11 @@ public:
     bool RemoveProfile(const uint8_t uuid[HOST_PROFILE_UUID_SIZE]) override;
     bool SetProfileImage(const uint8_t uuid[HOST_PROFILE_UUID_SIZE], const uint8_t * image_data, uint32_t image_size) override;
     bool GetProfileImagePath(const uint8_t uuid[HOST_PROFILE_UUID_SIZE], char * out_path, uint32_t out_path_size) const override;
+    void SetApplicationLaunchParameters(int32_t program_index, int32_t previous_program_index, ApplicationLaunchType launch_type) override;
+    void RegisterExecuteProgramCallback(ExecuteProgramCallback callback, void * userData) override;
+    void RegisterExitCallback(ExitCallback callback, void * userData) override;
+    void ExportUserChannel(UserChannelEntryCallback callback, void * userData) override;
+    void PushUserChannelEntry(const uint8_t * data, uint32_t size) override;
 
 private:
     OSManager() = delete;
@@ -70,4 +75,7 @@ private:
     ISystemModules & m_modules;
     Kernel::KProcess * m_applicationProcess;
     std::unique_ptr<EmuThread> m_emuThread;
+    int32_t m_programIndex;
+    int32_t m_previousProgramIndex;
+    ApplicationLaunchType m_launchType;
 };

--- a/src/nxemu/user_interface/sciter_main_window.cpp
+++ b/src/nxemu/user_interface/sciter_main_window.cpp
@@ -85,6 +85,9 @@ enum
     EVENT_FIRMWARE_INSTALL_DONE = 0x2005,
     EVENT_FIRMWARE_INSTALL_ACTIVE = 0x2006,
     EVENT_FIRMWARE_INSTALL_FINISHED = 0x2007,
+    EVENT_EXECUTE_PROGRAM = 0x2008,
+    EVENT_EXIT_PROGRAM = 0x2009,
+    EVENT_RELOAD_PROGRAM = 0x200A,
 };
 
 const uint32_t kKeyboardStateControl = 0x0040u | 0x0080u;
@@ -229,7 +232,12 @@ SciterMainWindow::SciterMainWindow(ISciterUI & sciterUI, const char * windowTitl
     m_mouseCursorHidden(false),
     m_lastMouseActivityTick(0),
     m_lastTrackedMouseX(0),
-    m_lastTrackedMouseY(0)
+    m_lastTrackedMouseY(0),
+    m_reloadingGame(false),
+    m_currentProgramIndex(0),
+    m_previousProgramIndex(-1),
+    m_pendingReloadProgramIndex(-1),
+    m_pendingReloadLaunchType(ApplicationLaunchType::FrontendInitiated)
 {
     SettingsStore & settings = SettingsStore::GetInstance();
     settings.RegisterCallback(NXCoreSetting::EmulationRunning, SciterMainWindow::EmulationRunning, this);
@@ -374,6 +382,101 @@ void SciterMainWindow::RegisterApplets()
     os.SetFrontendApplets(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &m_ProfileSelect, nullptr, &m_WebBrowser);
 }
 
+void SciterMainWindow::RegisterSystemCallbacks()
+{
+    if (!m_modules.IsValid())
+    {
+        return;
+    }
+    IOperatingSystem & os = m_modules.Modules().OperatingSystem();
+    os.RegisterExecuteProgramCallback(&SciterMainWindow::ExecuteProgramCallbackThunk, this);
+    os.RegisterExitCallback(&SciterMainWindow::ExitCallbackThunk, this);
+}
+
+void SciterMainWindow::CollectUserChannelEntry(const uint8_t * data, uint32_t size, void * userData)
+{
+    SciterMainWindow * impl = (SciterMainWindow *)userData;
+    if (data == nullptr || size == 0)
+    {
+        impl->m_pendingUserChannel.emplace_back();
+        return;
+    }
+    impl->m_pendingUserChannel.emplace_back(data, data + size);
+}
+
+void SciterMainWindow::ExecuteProgramCallbackThunk(size_t program_index, void * userData)
+{
+    SciterMainWindow * impl = (SciterMainWindow *)userData;
+    if (!impl->m_modules.IsValid())
+    {
+        return;
+    }
+
+    impl->m_pendingUserChannel.clear();
+    impl->m_modules.Modules().OperatingSystem().ExportUserChannel(&SciterMainWindow::CollectUserChannelEntry, impl);
+    impl->m_rootElement.PostEvent(EVENT_EXECUTE_PROGRAM, program_index);
+}
+
+void SciterMainWindow::ExitCallbackThunk(void * userData)
+{
+    SciterMainWindow * impl = static_cast<SciterMainWindow *>(userData);
+    impl->m_rootElement.PostEvent(EVENT_EXIT_PROGRAM);
+}
+
+void SciterMainWindow::OnExecuteProgram(uint64_t program_index)
+{
+    const std::string path = SettingsStore::GetInstance().GetString(NXCoreSetting::GameFile);
+    if (path.empty())
+    {
+        m_pendingUserChannel.clear();
+        return;
+    }
+    LoadGame(path.c_str(), (int32_t)program_index, ApplicationLaunchType::ApplicationInitiated);
+}
+
+void SciterMainWindow::OnExitProgram()
+{
+    if (m_reloadingGame)
+    {
+        return;
+    }
+    if (!m_emulationRunning)
+    {
+        return;
+    }
+    if (m_currentProgramIndex != 0)
+    {
+        const std::string path = SettingsStore::GetInstance().GetString(NXCoreSetting::GameFile);
+        if (!path.empty())
+        {
+            const int32_t previous_index = m_previousProgramIndex >= 0 ? m_previousProgramIndex : 0;
+            LoadGame(path.c_str(), previous_index, ApplicationLaunchType::ApplicationInitiated);
+            return;
+        }
+    }
+
+    AllowOSSleep();
+    SettingsStore::GetInstance().SetBool(NXCoreSetting::EmulationRunning, false);
+}
+
+void SciterMainWindow::OnReloadProgram()
+{
+    if (m_pendingReloadPath.empty())
+    {
+        m_reloadingGame = false;
+        return;
+    }
+
+    const std::string path = std::move(m_pendingReloadPath);
+    const int32_t program_index = m_pendingReloadProgramIndex;
+    const ApplicationLaunchType launch_type = m_pendingReloadLaunchType;
+    m_pendingReloadPath.clear();
+    m_pendingReloadProgramIndex = -1;
+    m_pendingReloadLaunchType = ApplicationLaunchType::FrontendInitiated;
+
+    LoadGame(path.c_str(), program_index, launch_type);
+}
+
 void SciterMainWindow::ResetMenu()
 {
     if (m_menuBar == nullptr)
@@ -510,6 +613,7 @@ bool SciterMainWindow::Show()
     CreateRenderWindow();
     m_modules.Setup(*this);
     RegisterApplets();
+    RegisterSystemCallbacks();
     ResetMenu();
     UpdateStatusWidgets();
     UpdateEmulationStatusText();
@@ -573,13 +677,38 @@ void SciterMainWindow::ShowGameConfig(const char * gamePath)
     m_rootElement.SetTimer(1, (uint32_t *)TIMER_OPEN_GAME_CONFIG);
 }
 
-void SciterMainWindow::LoadGame(const char * path)
+void SciterMainWindow::LoadGame(const char * path, int32_t program_index, ApplicationLaunchType launch_type)
 {
+    SettingsStore & settings = SettingsStore::GetInstance();
+    const int32_t previous_program_index = launch_type == ApplicationLaunchType::ApplicationInitiated ? m_currentProgramIndex : -1;
+    if (settings.GetBool(NXCoreSetting::EmulationRunning) && launch_type == ApplicationLaunchType::ApplicationInitiated)
+    {
+        m_pendingReloadPath = path != nullptr ? path : "";
+        m_pendingReloadProgramIndex = program_index;
+        m_pendingReloadLaunchType = launch_type;
+        m_reloadingGame = true;
+        settings.SetBool(NXCoreSetting::EmulationRunning, false);
+        return;
+    }
+
+    std::deque<std::vector<uint8_t>> pendingUserChannel = std::move(m_pendingUserChannel);
+    m_pendingUserChannel.clear();
+
     m_modules.Setup(*this);
     RegisterApplets();
+    RegisterSystemCallbacks();
+
+    IOperatingSystem & operatingSystem = m_modules.Modules().OperatingSystem();
+    for (const auto & entry : pendingUserChannel)
+    {
+        operatingSystem.PushUserChannelEntry(entry.data(), static_cast<uint32_t>(entry.size()));
+    }
 
     ISystemloader & loader = m_modules.Modules().Systemloader();
-    loader.LoadRom(path);
+    loader.LoadRom(path, program_index, previous_program_index, launch_type);
+    m_currentProgramIndex = program_index;
+    m_previousProgramIndex = previous_program_index;
+    m_reloadingGame = false;
     UpdateEmulationStatusText();
 }
 
@@ -808,6 +937,11 @@ void SciterMainWindow::EmulationRunning(const char * /*setting*/, void * userDat
     SciterMainWindow * impl = (SciterMainWindow *)userData;
     SettingsStore & settings = SettingsStore::GetInstance();
     impl->m_emulationRunning = settings.GetBool(NXCoreSetting::EmulationRunning);
+    if (!impl->m_emulationRunning && impl->m_pendingReloadProgramIndex != -1)
+    {
+        impl->m_rootElement.PostEvent(EVENT_RELOAD_PROGRAM);
+        return;
+    }
     impl->m_pendingStartInFullscreen = impl->m_emulationRunning && uiSettings.startGamesInFullscreen;
     impl->m_pendingStartWithUiHidden = impl->m_emulationRunning && uiSettings.startGamesWithUiHidden;
     if (!impl->m_emulationRunning && impl->m_win32Fullscreen && impl->m_win32Fullscreen->active)
@@ -922,6 +1056,10 @@ void SciterMainWindow::EmulationStateChanged(const char * /*setting*/, void * us
     }
     else if (state == EmulationState::Stopped)
     {
+        if (impl->m_reloadingGame)
+        {
+            return;
+        }
         impl->m_rootElement.PostEvent(EVENT_EMULATION_STOPPED);
     }
 }
@@ -1085,6 +1223,7 @@ void SciterMainWindow::OnOpenFile()
 
     m_modules.Setup(*this);
     RegisterApplets();
+    RegisterSystemCallbacks();
 
     ISystemloader & loader = m_modules.Modules().Systemloader();
     loader.SelectAndLoad((void *)m_window->GetHandle());
@@ -2285,7 +2424,7 @@ bool SciterMainWindow::OnTimer(SCITER_ELEMENT /*element*/, uint32_t * timerId)
     return true;
 }
 
-bool SciterMainWindow::OnEvent(SCITER_ELEMENT element, SCITER_ELEMENT /*source*/, uint32_t event_code, uint64_t /*reason*/)
+bool SciterMainWindow::OnEvent(SCITER_ELEMENT element, SCITER_ELEMENT /*source*/, uint32_t event_code, uint64_t reason)
 {
     if (event_code == static_cast<uint32_t>(SciterBehaviorEvent::PopupDismissed) && m_window != nullptr)
     {
@@ -2322,6 +2461,18 @@ bool SciterMainWindow::OnEvent(SCITER_ELEMENT element, SCITER_ELEMENT /*source*/
         m_shownFirstFrame = false;
         ResetMouseCursorHiding();
         ShowPanel(Panel::RomBrowser);
+    }
+    else if (event_code == EVENT_EXECUTE_PROGRAM)
+    {
+        OnExecuteProgram(reason);
+    }
+    else if (event_code == EVENT_RELOAD_PROGRAM)
+    {
+        OnReloadProgram();
+    }
+    else if (event_code == EVENT_EXIT_PROGRAM)
+    {
+        OnExitProgram();
     }
     else if (event_code == EVENT_EMULATION_FIRST_FRAME)
     {

--- a/src/nxemu/user_interface/sciter_main_window.h
+++ b/src/nxemu/user_interface/sciter_main_window.h
@@ -4,6 +4,7 @@
 #include "startup_checks.h"
 #include "user_interface/discord_presence.h"
 #include "user_interface/widgets/rom_browser.h"
+#include <deque>
 #include <map>
 #include <memory>
 #include <string>
@@ -93,7 +94,7 @@ public:
     bool Show();
     void ShowConfig(const char * startPage);
     void ShowGameConfig(const char * gamePath);
-    void LoadGame(const char * path);
+    void LoadGame(const char * path, int32_t program_index = 0, ApplicationLaunchType launch_type = ApplicationLaunchType::FrontendInitiated);
     void OpenGameSaveDataLocation(const char * gamePath);
     void OpenGameModDataLocation(const char * gamePath);
     void OpenSaveDataFolderForUser(uint64_t programId, const uint8_t uuidBytes[HOST_PROFILE_UUID_SIZE]);
@@ -130,6 +131,12 @@ private:
     void OnStopGame();
     void DoStopGame();
     void OnPauseContinueGame();
+    void OnExecuteProgram(uint64_t program_index);
+    void OnReloadProgram();
+    void OnExitProgram();
+    static void ExecuteProgramCallbackThunk(size_t program_index, void * userData);
+    static void ExitCallbackThunk(void * userData);
+    static void CollectUserChannelEntry(const uint8_t * data, uint32_t size, void * userData);
     void OnSystemConfig();
     void OnInputConfig();
     void OnInstallFirmwareFromFile();
@@ -175,6 +182,7 @@ private:
     void ShowPanel(Panel panel);
     void RefreshDiskCacheLoadingText();
     void RegisterApplets();
+    void RegisterSystemCallbacks();
 
     // IWindowDestroySink
     void OnWindowDestroy(HWINDOW hWnd) override;
@@ -229,6 +237,7 @@ private:
     bool m_useSpeedLimit;
     uint32_t m_speedLimit;
     bool m_emulationRunning;
+    bool m_reloadingGame;
     bool m_pendingStartInFullscreen;
     bool m_pendingStartWithUiHidden;
     std::map<std::string, std::string> m_menuIconSvgs;
@@ -245,4 +254,10 @@ private:
     int32_t m_lastTrackedMouseX;
     int32_t m_lastTrackedMouseY;
     DiscordPresence m_discordPresence;
+    std::deque<std::vector<uint8_t>> m_pendingUserChannel;
+    std::string m_pendingReloadPath;
+    int32_t m_currentProgramIndex;
+    int32_t m_previousProgramIndex;
+    int32_t m_pendingReloadProgramIndex;
+    ApplicationLaunchType m_pendingReloadLaunchType;
 };

--- a/src/nxemu/user_interface/widgets/rom_browser.cpp
+++ b/src/nxemu/user_interface/widgets/rom_browser.cpp
@@ -230,7 +230,7 @@ bool WidgetRomBrowser::RenderUI()
     return false;
 }
 
-bool WidgetRomBrowser::OnEvent(SCITER_ELEMENT element, SCITER_ELEMENT source, uint32_t event_code, uint64_t /*reason*/)
+bool WidgetRomBrowser::OnEvent(SCITER_ELEMENT /*element*/, SCITER_ELEMENT source, uint32_t event_code, uint64_t /*reason*/)
 {
     if (event_code == EVENT_UPDATE_LIST && !m_updatingUI)
     {


### PR DESCRIPTION
Wire AM ExecuteProgram / Exit through the OS module to the frontend so multi-program titles can switch programs and shut down cleanly.