### PR TITLE
nxemu-video: do not include version.h in the makefile, cause it only …

### DIFF
--- a/src/nxemu-video/CMakeLists.txt
+++ b/src/nxemu-video/CMakeLists.txt
@@ -19,7 +19,6 @@ set(NXEMU_VIDEO_SOURCES
     video_settings.cpp
     video_settings.h
     video_settings_identifiers.h
-    version.h
     render_window.h
 )
 


### PR DESCRIPTION
…generated and does not exist in the repository